### PR TITLE
feat: Allow custom OkHttpClient

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,23 @@ public class ChatPost {
 }
 ```
 
+If you need custom HTTP settings, provide your own `OkHttpClient`:
+
+```java
+import java.util.concurrent.TimeUnit;
+import okhttp3.OkHttpClient;
+
+OkHttpClient customClient = new OkHttpClient.Builder()
+        .callTimeout(30, TimeUnit.SECONDS)
+        .build();
+
+Cohere cohere = Cohere.builder()
+        .token("<<apiKey>>")
+        .clientName("snippet")
+        .httpClient(customClient)
+        .build();
+```
+
 ### Handling Errors
 When the API returns a non-success status code (4xx or 5xx response),
 a subclass of [ApiError](src/main/java/com/Cohere/api/core/ApiError.java)

--- a/src/main/java/com/cohere/api/CohereBuilder.java
+++ b/src/main/java/com/cohere/api/CohereBuilder.java
@@ -5,6 +5,7 @@ package com.cohere.api;
 
 import com.cohere.api.core.ClientOptions;
 import com.cohere.api.core.Environment;
+import okhttp3.OkHttpClient;
 
 public final class CohereBuilder {
     private ClientOptions.Builder clientOptionsBuilder = ClientOptions.builder();
@@ -39,6 +40,11 @@ public final class CohereBuilder {
 
     public CohereBuilder url(String url) {
         this.environment = Environment.custom(url);
+        return this;
+    }
+
+    public CohereBuilder httpClient(OkHttpClient httpClient) {
+        this.clientOptionsBuilder.httpClient(httpClient);
         return this;
     }
 

--- a/src/main/java/com/cohere/api/core/ClientOptions.java
+++ b/src/main/java/com/cohere/api/core/ClientOptions.java
@@ -80,6 +80,8 @@ public final class ClientOptions {
 
         private final Map<String, Supplier<String>> headerSuppliers = new HashMap<>();
 
+        private OkHttpClient httpClient;
+
         public Builder environment(Environment environment) {
             this.environment = environment;
             return this;
@@ -95,10 +97,18 @@ public final class ClientOptions {
             return this;
         }
 
+        public Builder httpClient(OkHttpClient httpClient) {
+            this.httpClient = httpClient;
+            return this;
+        }
+
         public ClientOptions build() {
-            OkHttpClient okhttpClient = new OkHttpClient.Builder()
-                    .addInterceptor(new RetryInterceptor(3))
-                    .build();
+            OkHttpClient okhttpClient = this.httpClient;
+            if (okhttpClient == null) {
+                okhttpClient = new OkHttpClient.Builder()
+                        .addInterceptor(new RetryInterceptor(3))
+                        .build();
+            }
             return new ClientOptions(environment, headers, headerSuppliers, okhttpClient);
         }
     }


### PR DESCRIPTION
## Summary
- allow passing a custom `OkHttpClient` when building `ClientOptions`
- expose new `httpClient` helper in `CohereBuilder`
- document custom client usage in README